### PR TITLE
adjust voting timeout

### DIFF
--- a/spec/pushy/integration/end_to_end_spec.rb
+++ b/spec/pushy/integration/end_to_end_spec.rb
@@ -190,7 +190,7 @@ describe "end-to-end-test" do
                                         'status' => 'online'
                                       }})
         end
-        job = wait_for_job_status(response['uri'], 'quorum_failed', :timeout => 20)
+        job = wait_for_job_status(response['uri'], 'quorum_failed', :timeout => 65)
         job['nodes'].should == { 'unavailable' => [ 'DONKEY' ] }
         # This verifies our assumption that this was caused by the TIMEOUT rather
         # than the node being detected as down


### PR DESCRIPTION
Default voting timeout is 60 in pushy server. This should allow this test to pass with a default configuration.
