### PR TITLE
md/oc5265 pushy client nacks if it is already running chef-client

### DIFF
--- a/spec/pushy/integration/end_to_end_spec.rb
+++ b/spec/pushy/integration/end_to_end_spec.rb
@@ -56,9 +56,9 @@ describe "end-to-end-test" do
       end
 
       it 'should nack when asked to commit to another job' do
-        job = start_job(echo_yahoo, %w{DONKEY})
+        job = start_job('chef-client', %w{DONKEY})
         get_job(job['uri']).should == {
-          'command' => echo_yahoo,
+          'command' => 'chef-client',
           'run_timeout' => 3600,
           'nodes' => { 'nacked' => [ 'DONKEY' ] },
           'status' => 'quorum_failed'


### PR DESCRIPTION
This assumes that chef-client creates a lockfile. Currently I think
this only happens in chef 11.

https://github.com/opscode/opscode-pushy-client/pull/28
