### PR TITLE
Make nodes busy for a little longer

### DIFF
--- a/spec/pushy/support/end_to_end_util.rb
+++ b/spec/pushy/support/end_to_end_util.rb
@@ -41,7 +41,7 @@ shared_context "end_to_end_util" do
   # @note Depending on the load the test machine is experiencing, this
   # sleep may need to be lengthened.
   def make_node_busy
-    'sleep 2'
+    'sleep 3'
   end
 
   # Method to start up a new client that will be reaped when


### PR DESCRIPTION
This is in response to more transient test failures in CI,
specifically
http://andra.ci.opscode.us/job/opscode-push-jobs-server-test/build_os=centos-5.5,machine_architecture=x86_64,project=opscode-push-jobs-server,role=tester/253/

This makes me rather sad.

cc: @schisamo @jkeiser @doubt72 @seth
