### PR TITLE
Add some debugging statements to catch a transient bug

### DIFF
--- a/spec/pushy/support/end_to_end_util.rb
+++ b/spec/pushy/support/end_to_end_util.rb
@@ -74,7 +74,14 @@ shared_context "end_to_end_util" do
 
       # Create chef client and save key for pushy client
       response = post(api_url("/clients"), superuser, :payload => {"name" => name})
+
+      require 'pp'
+      puts "Got a #{response.code} response to a POST to /clients for client #{name}:"
+      pp response
+
       key = parse(response)["private_key"]
+      puts "Private Key for client #{name}:"
+      pp key
 
       @clients[name][:key_file] = file = Tempfile.new([name, '.pem'])
       key_path = file.path


### PR DESCRIPTION
The following error pops up from time to time in CI tests:

```
The file /tmp/DONKEY20140224-8111-rar7rw.pem or :raw_key option does not contain a correctly formatted private key.
The key file should begin with '-----BEGIN RSA PRIVATE KEY-----' and end with '-----END RSA PRIVATE KEY-----'
Stacktrace

      The file /tmp/DONKEY20140224-8111-rar7rw.pem or :raw_key option does not contain a correctly formatted private key.
The key file should begin with '-----BEGIN RSA PRIVATE KEY-----' and end with '-----END RSA PRIVATE KEY-----'
./spec/pushy/support/end_to_end_util.rb:109:in `block in start_clients'
./spec/pushy/support/end_to_end_util.rb:69:in `each'
./spec/pushy/support/end_to_end_util.rb:69:in `start_clients'
./spec/pushy/support/end_to_end_util.rb:61:in `start_new_clients'
./spec/pushy/integration/end_to_end_spec.rb:50:in `block (3 levels) in <top (required)>'
./oc-pushy-pedant:17:in `<main>'
```

This is a transient thing, but when it does happen, there isn't really
any other information to go on.  It's also tough to reproduce locally.

I'm just going to add a bit of code to help debug when it pops up next
time.
